### PR TITLE
feat: add method to mask sensitive payload data in API requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,10 @@ addopts = "--cov=pymbrewclient --cov-report=term-missing --cov-report=xml"
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
 select = ["E", "F", "ANN", "UP"]
-ignore = ["E501", "ANN101"]
+ignore = ["E501"]
 
 [tool.black]
 line-length = 120

--- a/src/pymbrewclient/rest/client.py
+++ b/src/pymbrewclient/rest/client.py
@@ -148,9 +148,15 @@ class RestApiClient:
         :param json: Optional JSON data to send in the body.
         :return: The response object.
         """
-        safe_data = self._mask_sensitive_payload(data)
-        safe_json = self._mask_sensitive_payload(json)
-        logger.debug(f"POST request to {endpoint} with data: {safe_data}, json: {safe_json}")
+        if logger.is_enabled("DEBUG"):
+            safe_data = self._mask_sensitive_payload(data)
+            safe_json = self._mask_sensitive_payload(json)
+            logger.debug(
+                "POST request to {} with data: {}, json: {}",
+                endpoint,
+                safe_data,
+                safe_json,
+            )
         url = f"{self.base_url}/{endpoint}/"
         response = requests.post(url, headers=headers, data=data, json=json)
         response.raise_for_status()


### PR DESCRIPTION
This pull request introduces improved handling of sensitive information in logging within the `src/pymbrewclient/rest/client.py` module. The main enhancement is the addition of a utility to mask sensitive fields in request payloads before logging, which helps prevent accidental exposure of secrets in logs.

Sensitive data masking:

* Added a static method `_mask_sensitive_payload` to mask sensitive fields (e.g., passwords, tokens, secrets) in payloads by replacing their values with `"***"` before logging.
* Updated the `post` method to use `_mask_sensitive_payload` for both `data` and `json` payloads in debug logs, ensuring sensitive information is not written to logs.