### PR TITLE
chore: remove semantic-release/git plugin from configuration

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -121,7 +121,6 @@ jobs:
       - name: Install semantic-release
         run: |
           npm install -g semantic-release@23 \
-            @semantic-release/git@10 \
             @semantic-release/changelog@6 \
             @semantic-release/exec@6 \
             @semantic-release/github@10 \

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -61,13 +61,6 @@
           {"path": "dist/*.tar.gz", "label": "Source Distribution"}
         ]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
This pull request removes the use of the `@semantic-release/git` plugin from the release workflow. This simplifies the release process and reduces dependency complexity.

Release workflow simplification:

* [`.github/workflows/test-and-release.yml`](diffhunk://#diff-c34469acb6dfef04f199d518e466db578ba43f7be784fd981d08ae69457ffdcdL124): Removed installation of `@semantic-release/git@10` from the release job.
* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L64-L70): Removed configuration for the `@semantic-release/git` plugin, including its assets and release message settings.