### PR TITLE
refactor: streamline release process by removing build job and updating release notes configuration

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -65,48 +65,15 @@ jobs:
       - name: Run black
         run: black --check .
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [test, lint]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install build tools
-        run: |
-          pip install --upgrade pip
-          pip install build twine
-
-      - name: Build package
-        run: python -m build
-
-      - name: Check package
-        run: twine check dist/*
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: build-artifacts
-          path: dist/
-          retention-days: 7
-
   release:
     runs-on: ubuntu-latest
-    needs: [test, lint, build]
+    needs: [test, lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -129,21 +96,40 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release
 
-      - name: Download build artifacts
-        if: env.NEW_VERSION != ''
-        uses: actions/download-artifact@v7
-        with:
-          name: build-artifacts
-          path: dist/
+      - name: Check if release was created
+        id: check_release
+        run: |
+          if [ -f .semantic-release-version ]; then
+            echo "version=$(cat .semantic-release-version)" >> $GITHUB_OUTPUT
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout the new tag
+        if: steps.check_release.outputs.released == 'true'
+        run: |
+          git fetch --tags
+          git checkout "v${{ steps.check_release.outputs.version }}"
+
+      - name: Install build tools
+        if: steps.check_release.outputs.released == 'true'
+        run: |
+          pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        if: steps.check_release.outputs.released == 'true'
+        run: python -m build
+
+      - name: Check package
+        if: steps.check_release.outputs.released == 'true'
+        run: twine check dist/*
 
       - name: Publish to PyPI
-        if: env.NEW_VERSION != ''
+        if: steps.check_release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          skip-existing: true
+          verbose: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,46 +21,13 @@
         ]
       }
     ],
-    [
-      "@semantic-release/release-notes-generator",
-      {
-        "preset": "conventionalcommits",
-        "presetConfig": {
-          "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "perf", "section": "Performance Improvements"},
-            {"type": "revert", "section": "Reverts"},
-            {"type": "docs", "section": "Documentation"},
-            {"type": "refactor", "section": "Code Refactoring"},
-            {"type": "test", "section": "Tests"},
-            {"type": "build", "section": "Build System"},
-            {"type": "ci", "section": "CI/CD"}
-          ]
-        }
-      }
-    ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
-      }
-    ],
+    "@semantic-release/release-notes-generator",
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "echo 'NEW_VERSION=${nextRelease.version}' >> $GITHUB_ENV && git tag v${nextRelease.version}"
+        "prepareCmd": "echo '${nextRelease.version}' > .semantic-release-version"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {"path": "dist/*.whl", "label": "Python Wheel"},
-          {"path": "dist/*.tar.gz", "label": "Source Distribution"}
-        ]
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
This pull request updates the release workflow and configuration to simplify the build and release process, removing the separate build job and streamlining how releases are handled with semantic-release and PyPI publishing. The main changes involve consolidating build steps into the release job, updating the semantic-release configuration, and removing custom changelog and release notes generator settings.

**CI/CD workflow simplification:**

* Removed the separate `build` job from `.github/workflows/test-and-release.yml` and moved all build steps into the `release` job, ensuring packages are only built if a release is actually created.
* Updated the `release` job to check if a release was created by semantic-release before running build and publish steps, and improved artifact handling by building directly from the new git tag.

**Release configuration changes:**

* Simplified `.releaserc.json` by removing custom release notes generator and changelog plugins/configuration, and replaced the custom prepare command with a step that writes the version to `.semantic-release-version` for workflow use.
* Updated the GitHub release plugin configuration in `.releaserc.json` to use the default settings, removing the explicit asset specification.
