### PR TITLE
fix: update release notes generator configuration to include preset and types

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,7 +21,25 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {"type": "feat", "section": "Features"},
+            {"type": "fix", "section": "Bug Fixes"},
+            {"type": "perf", "section": "Performance Improvements"},
+            {"type": "revert", "section": "Reverts"},
+            {"type": "docs", "section": "Documentation"},
+            {"type": "refactor", "section": "Code Refactoring"},
+            {"type": "test", "section": "Tests"},
+            {"type": "build", "section": "Build System"},
+            {"type": "ci", "section": "CI/CD"}
+          ]
+        }
+      }
+    ],
     [
       "@semantic-release/exec",
       {


### PR DESCRIPTION
This pull request updates the release configuration to improve how release notes are generated. The main change is the addition of a custom configuration for the release notes generator to organize changes into clear sections based on commit types.

Release notes generation improvements:

* Updated `.releaserc.json` to configure `@semantic-release/release-notes-generator` with the `conventionalcommits` preset and a custom mapping of commit types to release note sections (e.g., Features, Bug Fixes, Documentation, etc.).
