### PR TITLE
feat: add beer_srm field to Device model and update brewery overview …

### DIFF
--- a/docs/API_EXAMPLES.md
+++ b/docs/API_EXAMPLES.md
@@ -26,6 +26,7 @@ The `get_brewery_overview()` method returns the current status of all devices in
             "beer_name": null,
             "recipe_version": null,
             "beer_style": null,
+            "beer_srm": null,
             "gravity": "1.00",
             "target_temp": null,
             "current_temp": null,
@@ -52,6 +53,7 @@ The `get_brewery_overview()` method returns the current status of all devices in
             "beer_name": "Example Beer",
             "recipe_version": "1",
             "beer_style": "Example Style",
+            "beer_srm": "12",
             "gravity": "1.00",
             "target_temp": 14.91,
             "current_temp": 15.1,
@@ -96,6 +98,7 @@ The response is organized into different categories based on device state:
 | `beer_name` | string/null | Name of beer being brewed/fermented |
 | `recipe_version` | string/null | Recipe version number |
 | `beer_style` | string/null | Style of beer |
+| `beer_srm` | string/null | Beer color value (SRM - Standard Reference Method) |
 | `gravity` | string | Current specific gravity reading |
 | `target_temp` | float/null | Target temperature in Celsius |
 | `current_temp` | float/null | Current temperature in Celsius |

--- a/src/pymbrewclient/cli.py
+++ b/src/pymbrewclient/cli.py
@@ -246,20 +246,20 @@ def get_minibrew_devices(
         overview = client.get_brewery_overview()
         all_devices = overview.brew_clean_idle + overview.fermenting + overview.serving + overview.brew_acid_clean_idle
 
-        # Only select unique devices and get only uuid, serial_number, title, and software version
+        # Only select unique devices
         unique_devices = list(
             {
-                device["uuid"]: device for device in all_devices if "uuid" in device and device["uuid"] is not None
+                device.uuid: device for device in all_devices if device.uuid is not None
             }.values()
         )
 
         selected_data = [
             {
-                "Serial Number": device["serial_number"],
-                "Nickname": device["title"],
-                "Version": device["software_version"],
-                "Is online": device["online"],
-                "Stage": device["stage"],
+                "Serial Number": device.serial_number,
+                "Nickname": device.title,
+                "Version": device.software_version,
+                "Is online": device.online,
+                "Stage": device.stage,
             }
             for device in unique_devices
         ]

--- a/src/pymbrewclient/cli.py
+++ b/src/pymbrewclient/cli.py
@@ -247,11 +247,7 @@ def get_minibrew_devices(
         all_devices = overview.brew_clean_idle + overview.fermenting + overview.serving + overview.brew_acid_clean_idle
 
         # Only select unique devices
-        unique_devices = list(
-            {
-                device.uuid: device for device in all_devices if device.uuid is not None
-            }.values()
-        )
+        unique_devices = list({device.uuid: device for device in all_devices if device.uuid is not None}.values())
 
         selected_data = [
             {

--- a/src/pymbrewclient/rest/models.py
+++ b/src/pymbrewclient/rest/models.py
@@ -34,6 +34,7 @@
 # SOFTWARE.
 #
 # Disclaimer: This software is an independent project and is not affiliated with, endorsed by, or associated with MiniBrew. MiniBrew's trademarks, logos, API, and other intellectual property are owned by MiniBrew and are not included in this software. Users are responsible for complying with MiniBrew's terms of service when using this software.
+import inspect
 from dataclasses import dataclass
 
 
@@ -53,6 +54,7 @@ class Device:
     beer_name: str | None
     recipe_version: str | None
     beer_style: str | None
+    beer_srm: str | None
     gravity: str
     target_temp: float | None
     current_temp: float | None
@@ -69,6 +71,27 @@ class BreweryOverview:
     fermenting: list[Device]
     serving: list[Device]
     brew_acid_clean_idle: list[Device]
+
+    def __post_init__(self) -> None:
+        """Convert device dictionaries to Device objects with defensive field filtering."""
+        _DEVICE_FIELDS = set(inspect.signature(Device).parameters)
+        
+        def _convert_devices(devices: list) -> list[Device]:
+            """Convert a list of device dictionaries to Device objects, filtering unknown keys."""
+            if not devices:
+                return []
+            result = []
+            for device in devices:
+                if isinstance(device, dict):
+                    result.append(Device(**{k: v for k, v in device.items() if k in _DEVICE_FIELDS}))
+                else:
+                    result.append(device)
+            return result
+        
+        self.brew_clean_idle = _convert_devices(self.brew_clean_idle)
+        self.fermenting = _convert_devices(self.fermenting)
+        self.serving = _convert_devices(self.serving)
+        self.brew_acid_clean_idle = _convert_devices(self.brew_acid_clean_idle)
 
 
 @dataclass

--- a/src/pymbrewclient/rest/models.py
+++ b/src/pymbrewclient/rest/models.py
@@ -75,7 +75,7 @@ class BreweryOverview:
     def __post_init__(self) -> None:
         """Convert device dictionaries to Device objects with defensive field filtering."""
         _DEVICE_FIELDS = set(inspect.signature(Device).parameters)
-        
+
         def _convert_devices(devices: list) -> list[Device]:
             """Convert a list of device dictionaries to Device objects, filtering unknown keys."""
             if not devices:
@@ -87,7 +87,7 @@ class BreweryOverview:
                 else:
                     result.append(device)
             return result
-        
+
         self.brew_clean_idle = _convert_devices(self.brew_clean_idle)
         self.fermenting = _convert_devices(self.fermenting)
         self.serving = _convert_devices(self.serving)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -215,7 +215,7 @@ class TestRestApiClient(unittest.TestCase):
             "is_starting": None,
             "software_version": "1.0.0",
         }
-        
+
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "brew_clean_idle": [mock_device],
@@ -294,7 +294,7 @@ class TestRestApiClient(unittest.TestCase):
             "unknown_field_1": "value1",
             "future_feature": 42,
         }
-        
+
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "brew_clean_idle": [mock_device],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,13 +189,39 @@ class TestRestApiClient(unittest.TestCase):
         """
         Test the get_brewery_overview method with non-empty data.
         """
-        # Mock the response from requests.get
+        # Mock the response from requests.get with complete device data
+        mock_device = {
+            "uuid": "test-uuid-1",
+            "serial_number": "SN12345",
+            "device_type": 0,
+            "user_action": 0,
+            "process_type": 0,
+            "title": "Test Device",
+            "sub_title": "Connected",
+            "session_id": None,
+            "image": "https://example.com/device.png",
+            "status_time": None,
+            "stage": "Idle",
+            "beer_name": None,
+            "recipe_version": None,
+            "beer_style": None,
+            "beer_srm": None,
+            "gravity": "1.00",
+            "target_temp": None,
+            "current_temp": None,
+            "online": True,
+            "updating": False,
+            "needs_acid_cleaning": False,
+            "is_starting": None,
+            "software_version": "1.0.0",
+        }
+        
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "brew_clean_idle": [{"uuid": "device-1"}],
-            "fermenting": [{"uuid": "device-2"}],
-            "serving": [{"uuid": "device-3"}],
-            "brew_acid_clean_idle": [{"uuid": "device-4"}],
+            "brew_clean_idle": [mock_device],
+            "fermenting": [],
+            "serving": [],
+            "brew_acid_clean_idle": [],
         }
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
@@ -210,9 +236,12 @@ class TestRestApiClient(unittest.TestCase):
         )
         self.assertIsInstance(overview, BreweryOverview)
         self.assertEqual(len(overview.brew_clean_idle), 1)
-        self.assertEqual(len(overview.fermenting), 1)
-        self.assertEqual(len(overview.serving), 1)
-        self.assertEqual(len(overview.brew_acid_clean_idle), 1)
+        self.assertEqual(len(overview.fermenting), 0)
+        self.assertEqual(len(overview.serving), 0)
+        self.assertEqual(len(overview.brew_acid_clean_idle), 0)
+        # Verify the device is properly converted to a Device object
+        self.assertEqual(overview.brew_clean_idle[0].uuid, "test-uuid-1")
+        self.assertEqual(overview.brew_clean_idle[0].serial_number, "SN12345")
 
     @patch("pymbrewclient.rest.client.requests.post")
     def test_get_token_error(self, mock_post: MagicMock) -> None:
@@ -229,6 +258,61 @@ class TestRestApiClient(unittest.TestCase):
             self.client._get_token()
         self.assertEqual(str(context.exception), "API error")
         mock_post.assert_called_once()
+
+    @patch("pymbrewclient.rest.client.requests.get")
+    @patch("pymbrewclient.rest.client.RestApiClient._ensure_token")
+    def test_get_brewery_overview_with_unknown_fields(self, mock_ensure_token: MagicMock, mock_get: MagicMock) -> None:
+        """
+        Test that unknown API fields are silently filtered and don't break the client.
+        """
+        # Mock device with known fields plus unknown future fields
+        mock_device = {
+            "uuid": "test-uuid-1",
+            "serial_number": "SN12345",
+            "device_type": 0,
+            "user_action": 0,
+            "process_type": 0,
+            "title": "Test Device",
+            "sub_title": "Connected",
+            "session_id": None,
+            "image": "https://example.com/device.png",
+            "status_time": None,
+            "stage": "Idle",
+            "beer_name": None,
+            "recipe_version": None,
+            "beer_style": None,
+            "beer_srm": None,
+            "gravity": "1.00",
+            "target_temp": None,
+            "current_temp": None,
+            "online": True,
+            "updating": False,
+            "needs_acid_cleaning": False,
+            "is_starting": None,
+            "software_version": "1.0.0",
+            # Unknown future fields that should be filtered out
+            "unknown_field_1": "value1",
+            "future_feature": 42,
+        }
+        
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "brew_clean_idle": [mock_device],
+            "fermenting": [],
+            "serving": [],
+            "brew_acid_clean_idle": [],
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Call the method - should not raise an exception
+        overview = self.client.get_brewery_overview()
+
+        # Verify the device is properly converted despite unknown fields
+        self.assertIsInstance(overview, BreweryOverview)
+        self.assertEqual(len(overview.brew_clean_idle), 1)
+        self.assertEqual(overview.brew_clean_idle[0].uuid, "test-uuid-1")
+        self.assertEqual(overview.brew_clean_idle[0].beer_srm, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request enhances the handling of device data in the brewery overview API, focusing on improved robustness and future-proofing. It introduces defensive filtering to ignore unknown fields from the API, adds support for the `beer_srm` (beer color) field, and updates documentation and tests accordingly.

**Device data handling and robustness:**

* Added a `__post_init__` method to the `BreweryOverview` model to automatically convert device dictionaries into `Device` objects, filtering out any unknown fields to prevent errors if the API adds new fields in the future.
* Updated the CLI and tests to use attribute access (`device.uuid`) instead of dictionary access, reflecting the stricter typing and conversion to `Device` objects. [[1]](diffhunk://#diff-1322bb4b2ee4e504e09dfcc2589719e6712e407e449a3f7aaf20827e83c44238L249-R262) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L192-R224) [[3]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L213-R244)

**API field and documentation updates:**

* Added the `beer_srm` field (beer color value) to the `Device` dataclass and updated the API documentation and example responses to include this new field. [[1]](diffhunk://#diff-9f998859dea03eaf34addc7669de9028757d2c8ee643b0013701dafdd2e512bfR57) [[2]](diffhunk://#diff-a5bd33c2ef8f3f1a53d314255508887abbed63463137da52467f1e3a83449238R29) [[3]](diffhunk://#diff-a5bd33c2ef8f3f1a53d314255508887abbed63463137da52467f1e3a83449238R56) [[4]](diffhunk://#diff-a5bd33c2ef8f3f1a53d314255508887abbed63463137da52467f1e3a83449238R101)

**Testing improvements:**

* Added and enhanced tests to verify that unknown future fields from the API are silently ignored and do not break client functionality, ensuring forward compatibility. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R262-R316) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L192-R224) [[3]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L213-R244)

These changes make the client library more robust to future API changes and provide better documentation and support for new device fields.
