### PR TITLE
fix: update logging implementation to use standard Python logging and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This library will **only work** if you have access to Minibrew's Pro Portal subs
 - Retrieve session information.
 - Easy-to-use CLI for quick access.
 - Python library for programmatic integration.
+- Uses standard Python logging and stays silent by default unless your application enables DEBUG for `pymbrewclient`.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
     "pydantic>=1.10.17,<3",
     "requests>=2.32.3,<3",
-    "loguru>=0.7.2,<1",
     "typer>=0.12.5,<1",
     "rich>=13.9.4,<16",
 ]

--- a/src/pymbrewclient/cli.py
+++ b/src/pymbrewclient/cli.py
@@ -33,16 +33,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-# Disclaimer: This software is an independent project and is not affiliated with, endorsed by, or associated with MiniBrew. MiniBrew's trademarks, logos, API, and other intellectual property are owned by MiniBrew and are not included in this software. Users are responsible for complying with MiniBrew's terms of service when using this software.import typer
+# Disclaimer: This software is an independent project and is not affiliated with, endorsed by, or associated with MiniBrew. MiniBrew's trademarks, logos, API, and other intellectual property are owned by MiniBrew and are not included in this software. Users are responsible for complying with MiniBrew's terms of service when using this software.
+
+import json
+import logging
+from typing import Annotated
+
 import typer
-from pymbrewclient.rest.client import RestApiClient
+from pydantic import BaseModel
 from rich import print as rich_print
 from rich.pretty import Pretty
-from loguru import logger
-import json
-from pydantic import BaseModel
-from typing import Annotated
-import sys
+
+from pymbrewclient.rest.client import RestApiClient
+
+
+logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="CLI for reading information from the Minibrew Pro Portal.", no_args_is_help=True)
 
@@ -68,9 +73,8 @@ def print_output(data: BaseModel | dict | list, format: str) -> None:
 
 
 def setup_logging(level: str) -> None:
-    """Configure loguru with the specified log level."""
-    logger.remove()  # Remove any default handlers
-    logger.add(sink=sys.stderr, level=level.upper())  # Add a new handler with the specified level
+    """Configure standard logging with the specified log level."""
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO), format="%(message)s", force=True)
 
 
 @app.callback()

--- a/src/pymbrewclient/cli.py
+++ b/src/pymbrewclient/cli.py
@@ -46,7 +46,6 @@ from rich.pretty import Pretty
 
 from pymbrewclient.rest.client import RestApiClient
 
-
 logger = logging.getLogger(__name__)
 
 app = typer.Typer(help="CLI for reading information from the Minibrew Pro Portal.", no_args_is_help=True)

--- a/src/pymbrewclient/rest/client.py
+++ b/src/pymbrewclient/rest/client.py
@@ -43,7 +43,6 @@ import requests
 
 from .models import ApiResponse, BreweryOverview, Session, TokenResponse
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/pymbrewclient/rest/client.py
+++ b/src/pymbrewclient/rest/client.py
@@ -33,13 +33,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-# Disclaimer: This software is an independent project and is not affiliated with, endorsed by, or associated with MiniBrew. MiniBrew's trademarks, logos, API, and other intellectual property are owned by MiniBrew and are not included in this software. Users are responsible for complying with MiniBrew's terms of service when using this software.import requests
+# Disclaimer: This software is an independent project and is not affiliated with, endorsed by, or associated with MiniBrew. MiniBrew's trademarks, logos, API, and other intellectual property are owned by MiniBrew and are not included in this software. Users are responsible for complying with MiniBrew's terms of service when using this software.
 
-from typing import Any
-import requests
+import logging
 import time
-from .models import TokenResponse, ApiResponse, BreweryOverview, Session
-from loguru import logger
+from typing import Any
+
+import requests
+
+from .models import ApiResponse, BreweryOverview, Session, TokenResponse
+
+
+logger = logging.getLogger(__name__)
 
 
 class RestApiClient:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,7 @@
+import io
+import logging
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 from pymbrewclient.rest.client import RestApiClient
 from pymbrewclient.rest.models import TokenResponse, BreweryOverview, Beer
 
@@ -27,6 +29,59 @@ class TestRestApiClient(unittest.TestCase):
         self.assertEqual(token_response.token, "mock_token")
         self.assertGreater(self.client.token_expiry, 0)
         self.assertEqual(self.client.headers["Authorization"], "Bearer mock_token")
+
+    def test_debug_logging_is_silent_by_default(self) -> None:
+        """Debug logging should not emit anything unless the host configures it."""
+        library_logger = logging.getLogger("pymbrewclient.rest.client")
+        root_logger = logging.getLogger()
+
+        original_logger_level = library_logger.level
+        original_root_level = root_logger.level
+        original_root_handlers = root_logger.handlers[:]
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+
+        try:
+            library_logger.setLevel(logging.NOTSET)
+            root_logger.handlers = [handler]
+            root_logger.setLevel(logging.WARNING)
+
+            self.client.token = None
+            self.client._is_token_valid()
+
+            self.assertEqual(stream.getvalue(), "")
+        finally:
+            root_logger.handlers = original_root_handlers
+            root_logger.setLevel(original_root_level)
+            library_logger.setLevel(original_logger_level)
+
+    def test_debug_logging_follows_host_configuration(self) -> None:
+        """Debug logging should appear when the host explicitly enables it."""
+        library_logger = logging.getLogger("pymbrewclient.rest.client")
+        root_logger = logging.getLogger()
+
+        original_logger_level = library_logger.level
+        original_root_level = root_logger.level
+        original_root_handlers = root_logger.handlers[:]
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setLevel(logging.DEBUG)
+
+        try:
+            library_logger.setLevel(logging.NOTSET)
+            root_logger.handlers = [handler]
+            root_logger.setLevel(logging.DEBUG)
+
+            self.client.token = None
+            self.client._is_token_valid()
+
+            self.assertIn("Token is invalid or expired.", stream.getvalue())
+        finally:
+            root_logger.handlers = original_root_handlers
+            root_logger.setLevel(original_root_level)
+            library_logger.setLevel(original_logger_level)
 
     @patch("pymbrewclient.rest.client.RestApiClient._get_token")
     @patch("pymbrewclient.rest.client.requests.get")


### PR DESCRIPTION
This pull request migrates the logging system from `loguru` to standard Python logging throughout the `pymbrewclient` library and CLI. The goal is to ensure the library remains silent by default, only emitting logs when the host application configures logging (especially at the DEBUG level). The changes also add explicit documentation and tests to confirm this behavior.

**Migration to standard Python logging:**

* Replaced all uses of `loguru` with the standard `logging` module in both `src/pymbrewclient/cli.py` and `src/pymbrewclient/rest/client.py`, and removed `loguru` from dependencies in `pyproject.toml`. [[1]](diffhunk://#diff-1322bb4b2ee4e504e09dfcc2589719e6712e407e449a3f7aaf20827e83c44238L36-R50) [[2]](diffhunk://#diff-2d6e49871d1d316f6aa49184bf804bf47bf4b991c3f94f3471b3520d67c5d8beL36-R47) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L26)

**Default silent logging and developer documentation:**

* Updated the `README.md` to explicitly state that the library uses standard Python logging and is silent by default unless DEBUG logging is enabled for `pymbrewclient`.

**CLI logging behavior:**

* Updated the CLI's `setup_logging` function to use standard logging configuration, ensuring consistent log level handling.

**Testing logging behavior:**

* Added unit tests to verify that debug logging is silent by default and only appears when explicitly enabled by the host application. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R33-R85) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R1-R4)
